### PR TITLE
changed the provider url for api request

### DIFF
--- a/NZBmegasearch/ApiModule.py
+++ b/NZBmegasearch/ApiModule.py
@@ -430,7 +430,7 @@ class ApiResponses:
                     'filesize': results[i]['size'],
                     'age': human_readable_time,
                     'providertitle': results[i]['providertitle'],
-                    'providerurl': results[i]['provider']
+                    'providerurl': 'http://www.derefer.me/?' + results[i]['release_comments']
                 }
 
                 # ~ non CP request generate might errors if no url is found in the permalink


### PR DESCRIPTION
Sometimes, I wanted to go see some details about the nzb I wanted to downloaded when I was doing some manual searches in Sonarr. Orginally, the url provided for the nzb's detail page was the main url for the provider.  Now when you click on the title of the nzb in the Sonarr search window, it will take you to the nzb's specific url instead of the provider's home page.  This is the same link that NZBmegasearch gives on the far right column on its search results page.
